### PR TITLE
Ensure state becomes "interrupt"

### DIFF
--- a/lib/interruptible.js
+++ b/lib/interruptible.js
@@ -124,7 +124,8 @@ Interruptible.prototype._checkInterrupt = function(interruptPriority, insertedTa
         // Because we've already added ourselves to the list.
         if(task !== insertedTask) {
           tasks.push(function(done) {
-            task.on("end", done);
+            done();
+            //task.on("end", done);
             task.interrupt();
           });
         }

--- a/lib/interruptible.js
+++ b/lib/interruptible.js
@@ -40,11 +40,11 @@ Interruptible.prototype.add = function(priority, taskDef) {
 
   // `cancelSiblings` is just so the task priorities read a bit nicer
   if(taskDef.cancelSiblings) {
-    interruptPriority = priority + 1;
+    interruptPriority = +priority + 0.5;
   } else if(taskDef.cancelLower) {
-    interruptPriority = priority;
+    interruptPriority = +priority;
   } else {
-    interruptPriority = priority;
+    interruptPriority = +priority;
     dontInterrupt = true;
   }
 

--- a/lib/interruptible.js
+++ b/lib/interruptible.js
@@ -5,6 +5,7 @@ var Task = require("./task");
 function Interruptible(opts) {
   opts = opts || {};
   this._priorityList = {};
+  this._priorityOrder = [];
   this._timestep = opts.timestep || 100;
   this._loopHdl = null;
 
@@ -12,16 +13,18 @@ function Interruptible(opts) {
   this._loop = this._loop.bind(this);
 }
 
-Interruptible.prototype._loop = function(t) {
-  var plist = this._priorityList
-  var now = t || Date.now();
-
-  // Yes I know this inefficient... sorry I'll fix it soon
-  var keys = Object.keys(plist).sort(function(a,b) {
+Interruptible.prototype._updatePriorityOrder = function() {
+  this._priorityOrder = Object.keys(this._priorityList).sort(function(a,b) {
     return a > b;
   });
+};
 
-  keys.forEach(function(k) {
+Interruptible.prototype._loop = function(t) {
+  var plist = this._priorityList;
+  var pOrder = this._priorityOrder;
+  var now = t || Date.now();
+
+  pOrder.forEach(function(k) {
     var list = plist[k];
     list.forEach(function(item) {
       // True means it's done.
@@ -32,7 +35,8 @@ Interruptible.prototype._loop = function(t) {
 
 Interruptible.prototype.add = function(priority, taskDef) {
   var interruptPriority;
-  var dontInterrupt;
+  var dontInterrupt = false;
+  var thisInterruptible = this;
 
   // `cancelSiblings` is just so the task priorities read a bit nicer
   if(taskDef.cancelSiblings) {
@@ -53,12 +57,14 @@ Interruptible.prototype.add = function(priority, taskDef) {
   var l = this._priorityList[priority] = this._priorityList[priority] || [];
   var t = new Task(taskDef);
   l.push(t);
+  this._updatePriorityOrder();
 
   // When we end, remove ourselves from the list.
   t.on("end", function() {
     var idx = l.indexOf(t);
     if (idx > -1) {
       l.splice(idx, 1);
+      thisInterruptible._updatePriorityOrder();
     }
   });
 
@@ -86,7 +92,7 @@ Interruptible.prototype._maxPriority = function() {
 
 Interruptible.prototype._priorities = function() {
   this._wipeEmptyLists();
-  return Object.keys(this._priorityList).sort();
+  return this._priorityOrder;
 };
 
 
@@ -97,6 +103,7 @@ Interruptible.prototype._wipeEmptyLists = function() {
       delete this._priorityList[k];
     }
   }
+  this._updatePriorityOrder();
 }
 
 /**

--- a/lib/task.js
+++ b/lib/task.js
@@ -68,12 +68,11 @@ Task.prototype.start = function() {
 };
 
 Task.prototype.interrupt = function() {
-  // Just end the task if disabled.
+  this._state = "interrupt";
+  // End the task if disabled.
   if(this._disabled) {
     this.emit("end");
-  } else {
-    this._state = "interrupt";
-  }
+  } 
 };
 
 Task.prototype.toJSON = function() {


### PR DESCRIPTION
Newly created tasks are disabled, so never interrupt if they've not run.

This causes problems down the line when trying to interrupt all tasks due to a state change in the main app (in our case, when the serial port closes) - the end event gets emitted repeatedly and async falls over because a callback gets called more than once. Except all that got papered over by the try-catch in the .exec() method.

To consider: removing the try-catch as well. I'm not sure it helps anyone. If the idea is to guard against the third party code crashing, then it needs to be down in TaskProcess
